### PR TITLE
Moving some Techs to Ultra level

### DIFF
--- a/1.4/Mods/Biotech/Defs/ResearchProjectDefs/ResearchProjects_Mechanitor.xml
+++ b/1.4/Mods/Biotech/Defs/ResearchProjectDefs/ResearchProjects_Mechanitor.xml
@@ -50,6 +50,7 @@
 		<label>ultra-heavy alpha mechs</label>
 		<description>The advanced technology needed for your mechanitor to create and control ultra-tier alpha mechanoids.</description>
 		<baseCost>2500</baseCost>
+		<techLevel>Ultra</techLevel>
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>0.00</researchViewY>
 		<prerequisites>
@@ -64,6 +65,7 @@
 		<label>mechanoid beamcasting</label>
 		<description>Research technology that harnesses advanced energy manipulation techniques to create focused and directed energy beams that can be transmitted across vast distances, and enable the summoning of the formidable Infernus mechanoid.</description>
 		<baseCost>500</baseCost>
+		<techLevel>Ultra</techLevel>
 		<researchViewX>0.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<prerequisites>
@@ -78,6 +80,7 @@
 		<label>voidlink connectivity</label>
 		<description>A communication method that operates on a framework of relay stations positioned across the system. These relay stations, known as "voidlinks," use subspace communication technology to transmit messages at near-light speed, allowing for rapid communication across sub-stellar distances. Enables the summoning of the War Empress mechanoid.</description>
 		<baseCost>500</baseCost>
+		<techLevel>Ultra</techLevel>
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<prerequisites>
@@ -95,6 +98,7 @@
 		<label>quantum pulse messaging</label>
 		<description>A cutting-edge communication system that leverages the principles of quantum mechanics to transmit information using more than just binary states of 0s and 1s. The use of these qubits allows for the transmission of complex data, instructions, or commands in a highly efficient and secure manner. Enables the summoning of the Apoptosis mechanoid.</description>
 		<baseCost>500</baseCost>
+		<techLevel>Ultra</techLevel>
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<prerequisites>
@@ -106,12 +110,13 @@
 		</requiredStudied>
 		<tab>AM_AlphaMechs</tab>
 	</ResearchProjectDef>
-	
+
 	<ResearchProjectDef ParentName="AM_MechtechBase">
 		<defName>AM_Cryptoharmonization</defName>
 		<label>crypto-harmonization</label>
 		<description>A technology that involves the use of advanced cryptographic algorithms to achieve perfect synchronization and coordination between multiple mechanoid units or systems. It allows for seamless communication, information exchange, and coordination.</description>
 		<baseCost>500</baseCost>
+		<techLevel>Ultra</techLevel>
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<prerequisites>

--- a/1.4/Mods/VanillaMechanoidsExpanded/Patches/ResearchProjectDefPatch.xml
+++ b/1.4/Mods/VanillaMechanoidsExpanded/Patches/ResearchProjectDefPatch.xml
@@ -12,6 +12,7 @@
 					<label>alpha hardware upgrade</label>
 					<description>Researching the mechanoid hardware upgrade will allow you to build all the advanced alpha mechs added in Vanilla Factions Expanded - Mechanoid.</description>
 					<baseCost>1000</baseCost>
+					<techLevel>Ultra</techLevel>
 					<researchViewX>4.00</researchViewX>
 					<researchViewY>0.00</researchViewY>
 					<prerequisites>


### PR DESCRIPTION
Hi, while playing I noticed some techs being Industrial while relying on the Ultra level tech "UltraMechtech" this moves all those techs up to Ultra as well. (Atleast I don't think I missed any)

While in itself not a problem I don't think I have ever seen a tech rely on a tech that is of higher techlevel.
This change as far as I'm aware shouldn't cause any issues but if necessary the baseCost could be adjusted downwards in turn although they are already relatively low.

This also fixes some interactions with atleast the following mods and probably some others as well:
-Semi Random Research isn't hardlocking the player on Industrial when using "restrict to tech level" (preventing all further research)
-TechAdvancing is no longer locking the player to Industrial when using "Rule A"
-ResearchPowl tree looks proper now